### PR TITLE
✨ Indexer Status Server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,6 +54,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59d2a3357dde987206219e78ecfbbb6e8dad06cbb65292758d3270e6254f7355"
+
+[[package]]
 name = "arc-swap"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -163,6 +169,28 @@ dependencies = [
  "pin-utils",
  "slab",
  "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -1846,6 +1874,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1911,6 +1951,7 @@ dependencies = [
  "hyper",
  "mime",
  "mpart-async",
+ "prost",
  "rstest",
  "rustls 0.20.9",
  "rustls-native-certs",
@@ -1924,6 +1965,7 @@ dependencies = [
  "tokio",
  "tokio-postgres",
  "tokio-postgres-rustls",
+ "tonic",
  "tower",
  "tower-http",
  "tracing",
@@ -1981,6 +2023,15 @@ dependencies = [
  "hermit-abi",
  "rustix 0.38.13",
  "windows-sys",
+]
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -2419,6 +2470,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c289cda302b98a28d40c8b3b90498d6e526dd24ac2ecea73e4e491685b94a"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -3098,6 +3172,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-io-timeout"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-macros"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3243,6 +3327,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d560933a0de61cf715926b9cac824d4c883c2c43142f787595e48280c40a1d0e"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3250,9 +3361,13 @@ checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
+ "rand",
+ "slab",
  "tokio",
+ "tokio-util 0.7.8",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ dotenvy = "0.15"
 futures-util = "0.3.21"
 hyper = { version = "0.14", features = ["full"] }
 mime = "0.3"
+prost = "0.12.3"
 rstest = "0.18.2"
 rustls = "0.20.8"
 rustls-native-certs = "0.6.2"
@@ -45,13 +46,12 @@ tokio = { version = "1.0", features = [
 ] }
 tokio-postgres = "0.7.7"
 tokio-postgres-rustls = "0.9.0"
+tonic = "0.10.2"
 tower-http = { version = "0.4.0", features = ["trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1.4", features = ["fast-rng", "v4", "serde"] }
 value-bag = "1.4.1"
-tonic = "0.10.2"
-prost = "0.12.3"
 
 [dev-dependencies]
 tower = { version = "0.4", features = ["util"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,8 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1.4", features = ["fast-rng", "v4", "serde"] }
 value-bag = "1.4.1"
+tonic = "0.10.2"
+prost = "0.12.3"
 
 [dev-dependencies]
 tower = { version = "0.4", features = ["util"] }

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -1,7 +1,6 @@
 version: "3"
 
 services:
-
   indexing:
     build: .
     env_file:
@@ -22,15 +21,15 @@ services:
     image: localstack/localstack:2.0
     hostname: localstack
     ports:
-      - '4566:4566' # LocalStack endpoint
-      - '4510-4559:4510-4559' # external services port range
+      - "4566:4566" # LocalStack endpoint
+      - "4510-4559:4510-4559" # external services port range
     environment:
       - SERVICES=sqs,s3
       - DOCKER_HOST=unix:///var/run/docker.sock
       - HOSTNAME_EXTERNAL=localstack
     volumes:
       - ./scripts/setup-localstack.sh:/etc/localstack/init/ready.d/script.sh
-      - '/var/run/docker.sock:/var/run/docker.sock'
+      - "/var/run/docker.sock:/var/run/docker.sock"
     networks:
       - ls
 

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -6,6 +6,13 @@ services:
     build: .
     env_file:
       - .env
+    environment:
+      - APIBARA_ETCD_URL=http://host.docker.internal:2379
+      - LOCALSTACK_ENDPOINT=http://localstack:4566
+      - DATABASE_URL=postgres://postgres:postgres@host.docker.internal:5432
+      - APIBARA_POSTGRES_CONNECTION_STRING=postgres://postgres:postgres@host.docker.internal:5432/postgres
+      - AWS_ACCESS_KEY_ID=test
+      - AWS_SECRET_ACCESS_KEY=test
     ports:
       - 8080:8080
     networks:

--- a/examples/pragma/mainnet/mainnet-script-future.js
+++ b/examples/pragma/mainnet/mainnet-script-future.js
@@ -1,81 +1,81 @@
 import { hash, shortString } from "https://esm.run/starknet@5.14";
 
 const filter = {
-	// Only request header if any event matches.
-	header: {
-		weak: true,
-	},
-	events: [
-		{
-			fromAddress:
-				"0x2a85bd616f912537c50a49a4076db02c00b29b2cdc8a197ce92ed1837fa875b",
-			keys: [hash.getSelectorFromName("SubmittedFutureEntry")],
-		},
-	],
+  // Only request header if any event matches.
+  header: {
+    weak: true,
+  },
+  events: [
+    {
+      fromAddress:
+        "0x2a85bd616f912537c50a49a4076db02c00b29b2cdc8a197ce92ed1837fa875b",
+      keys: [hash.getSelectorFromName("SubmittedFutureEntry")],
+    },
+  ],
 };
 
 function escapeInvalidCharacters(str) {
-	return str.replace(/^[\x00-\x1F]+/, "");
+  return str.replace(/^[\x00-\x1F]+/, "");
 }
 
 function decodeTransfersInBlock({ header, events }) {
-	const { blockNumber, blockHash, timestamp } = header;
-	return events.map(({ event, receipt }) => {
-		const { transactionHash } = receipt;
-		const dataId = `${transactionHash}_${event.index}`;
+  const { blockNumber, blockHash, timestamp } = header;
+  return events.map(({ event, receipt }) => {
+    const { transactionHash } = receipt;
+    const dataId = `${transactionHash}_${event.index}`;
 
-		const [
-			entryTimestamp,
-			source,
-			publisher,
-			price,
-			pairId,
-			volume,
-			expirationTimestamp,
-		] = event.data;
+    const [
+      entryTimestamp,
+      source,
+      publisher,
+      price,
+      pairId,
+      volume,
+      expirationTimestamp,
+    ] = event.data;
 
-		// Convert felts to string
-		const publisherName = escapeInvalidCharacters(
-			shortString.decodeShortString(publisher)
-		);
-		const sourceName = escapeInvalidCharacters(
-			shortString.decodeShortString(source)
-		);
-		const pairIdName = escapeInvalidCharacters(
-			shortString.decodeShortString(pairId)
-		);
+    // Convert felts to string
+    const publisherName = escapeInvalidCharacters(
+      shortString.decodeShortString(publisher),
+    );
+    const sourceName = escapeInvalidCharacters(
+      shortString.decodeShortString(source),
+    );
+    const pairIdName = escapeInvalidCharacters(
+      shortString.decodeShortString(pairId),
+    );
 
-		// Convert to snake_case because it works better with postgres.
-		return {
-			network: "starknet-mainnet",
-			pair_id: pairIdName,
-			data_id: dataId,
-			block_hash: blockHash,
-			block_number: +blockNumber,
-			block_timestamp: timestamp,
-			transaction_hash: transactionHash,
-			price: +price,
-			timestamp: new Date(Number(entryTimestamp) * 1000).toISOString(),
-			publisher: publisherName,
-			source: sourceName,
-			volume: +volume,
-			expiration_timestamp: new Date(Number(expirationTimestamp)).toISOString(),
-		};
-	});
+    // Convert to snake_case because it works better with postgres.
+    return {
+      network: "starknet-mainnet",
+      pair_id: pairIdName,
+      data_id: dataId,
+      block_hash: blockHash,
+      block_number: +blockNumber,
+      block_timestamp: timestamp,
+      transaction_hash: transactionHash,
+      price: +price,
+      timestamp: new Date(Number(entryTimestamp) * 1000).toISOString(),
+      publisher: publisherName,
+      source: sourceName,
+      volume: +volume,
+      expiration_timestamp: new Date(Number(expirationTimestamp)).toISOString(),
+    };
+  });
 }
 
 // Configure indexer for streaming Starknet Goerli data starting at the specified block.
 export const config = {
-	streamUrl: "https://pragma-mainnet.starknet.a5a.ch",
-	startingBlock: 416000,
-	network: "starknet",
-	filter,
-	sinkType: "postgres",
-	sinkOptions: {
-		// Send data as returned by `transform`.
-		// When `raw = false`, the data is sent together with the starting and end cursor.
-		raw: true,
-	},
+  streamUrl: "https://pragma-mainnet.starknet.a5a.ch",
+  startingBlock: 416000,
+  network: "starknet",
+  filter,
+  sinkType: "postgres",
+  sinkOptions: {
+    // Send data as returned by `transform`.
+    // When `raw = false`, the data is sent together with the starting and end cursor.
+    raw: true,
+  },
 };
 
 // Transform each block using the function defined in starknet.js.

--- a/examples/pragma/mainnet/mainnet-script-spot.js
+++ b/examples/pragma/mainnet/mainnet-script-spot.js
@@ -1,73 +1,73 @@
 import { hash, shortString } from "https://esm.run/starknet@5.14";
 
 const filter = {
-	// Only request header if any event matches.
-	header: {
-		weak: true,
-	},
-	events: [
-		{
-			fromAddress:
-				"0x2a85bd616f912537c50a49a4076db02c00b29b2cdc8a197ce92ed1837fa875b",
-			keys: [hash.getSelectorFromName("SubmittedSpotEntry")],
-		},
-	],
+  // Only request header if any event matches.
+  header: {
+    weak: true,
+  },
+  events: [
+    {
+      fromAddress:
+        "0x2a85bd616f912537c50a49a4076db02c00b29b2cdc8a197ce92ed1837fa875b",
+      keys: [hash.getSelectorFromName("SubmittedSpotEntry")],
+    },
+  ],
 };
 
 function escapeInvalidCharacters(str) {
-	return str.replace(/^[\x00-\x1F]+/, "");
+  return str.replace(/^[\x00-\x1F]+/, "");
 }
 
 function decodeTransfersInBlock({ header, events }) {
-	const { blockNumber, blockHash, timestamp } = header;
-	return events.map(({ event, receipt }) => {
-		const { transactionHash } = receipt;
-		const dataId = `${transactionHash}_${event.index}`;
+  const { blockNumber, blockHash, timestamp } = header;
+  return events.map(({ event, receipt }) => {
+    const { transactionHash } = receipt;
+    const dataId = `${transactionHash}_${event.index}`;
 
-		const [entryTimestamp, source, publisher, price, pairId, volume] =
-			event.data;
+    const [entryTimestamp, source, publisher, price, pairId, volume] =
+      event.data;
 
-		// Convert felts to string
-		const publisherName = escapeInvalidCharacters(
-			shortString.decodeShortString(publisher)
-		);
-		const sourceName = escapeInvalidCharacters(
-			shortString.decodeShortString(source)
-		);
-		const pairIdName = escapeInvalidCharacters(
-			shortString.decodeShortString(pairId)
-		);
+    // Convert felts to string
+    const publisherName = escapeInvalidCharacters(
+      shortString.decodeShortString(publisher),
+    );
+    const sourceName = escapeInvalidCharacters(
+      shortString.decodeShortString(source),
+    );
+    const pairIdName = escapeInvalidCharacters(
+      shortString.decodeShortString(pairId),
+    );
 
-		// Convert to snake_case because it works better with postgres.
-		return {
-			network: "starknet-mainnet",
-			pair_id: pairIdName,
-			data_id: dataId,
-			block_hash: blockHash,
-			block_number: +blockNumber,
-			block_timestamp: timestamp,
-			transaction_hash: transactionHash,
-			price: +price,
-			timestamp: new Date(Number(entryTimestamp) * 1000).toISOString(),
-			publisher: publisherName,
-			source: sourceName,
-			volume: +volume,
-		};
-	});
+    // Convert to snake_case because it works better with postgres.
+    return {
+      network: "starknet-mainnet",
+      pair_id: pairIdName,
+      data_id: dataId,
+      block_hash: blockHash,
+      block_number: +blockNumber,
+      block_timestamp: timestamp,
+      transaction_hash: transactionHash,
+      price: +price,
+      timestamp: new Date(Number(entryTimestamp) * 1000).toISOString(),
+      publisher: publisherName,
+      source: sourceName,
+      volume: +volume,
+    };
+  });
 }
 
 // Configure indexer for streaming Starknet Goerli data starting at the specified block.
 export const config = {
-	streamUrl: "https://pragma-mainnet.starknet.a5a.ch",
-	startingBlock: 416000,
-	network: "starknet",
-	filter,
-	sinkType: "postgres",
-	sinkOptions: {
-		// Send data as returned by `transform`.
-		// When `raw = false`, the data is sent together with the starting and end cursor.
-		raw: true,
-	},
+  streamUrl: "https://pragma-mainnet.starknet.a5a.ch",
+  startingBlock: 416000,
+  network: "starknet",
+  filter,
+  sinkType: "postgres",
+  sinkOptions: {
+    // Send data as returned by `transform`.
+    // When `raw = false`, the data is sent together with the starting and end cursor.
+    raw: true,
+  },
 };
 
 // Transform each block using the function defined in starknet.js.

--- a/examples/pragma/testnet/goerli-script-future.js
+++ b/examples/pragma/testnet/goerli-script-future.js
@@ -1,81 +1,81 @@
 import { hash, shortString } from "https://esm.run/starknet@5.14";
 
 const filter = {
-	// Only request header if any event matches.
-	header: {
-		weak: true,
-	},
-	events: [
-		{
-			fromAddress:
-				"0x6df335982dddce41008e4c03f2546fa27276567b5274c7d0c1262f3c2b5d167",
-			keys: [hash.getSelectorFromName("SubmittedFutureEntry")],
-		},
-	],
+  // Only request header if any event matches.
+  header: {
+    weak: true,
+  },
+  events: [
+    {
+      fromAddress:
+        "0x6df335982dddce41008e4c03f2546fa27276567b5274c7d0c1262f3c2b5d167",
+      keys: [hash.getSelectorFromName("SubmittedFutureEntry")],
+    },
+  ],
 };
 
 function escapeInvalidCharacters(str) {
-	return str.replace(/^[\x00-\x1F]+/, "");
+  return str.replace(/^[\x00-\x1F]+/, "");
 }
 
 function decodeTransfersInBlock({ header, events }) {
-	const { blockNumber, blockHash, timestamp } = header;
-	return events.map(({ event, receipt }) => {
-		const { transactionHash } = receipt;
-		const dataId = `${transactionHash}_${event.index}`;
+  const { blockNumber, blockHash, timestamp } = header;
+  return events.map(({ event, receipt }) => {
+    const { transactionHash } = receipt;
+    const dataId = `${transactionHash}_${event.index}`;
 
-		const [
-			entryTimestamp,
-			source,
-			publisher,
-			price,
-			pairId,
-			volume,
-			expirationTimestamp,
-		] = event.data;
+    const [
+      entryTimestamp,
+      source,
+      publisher,
+      price,
+      pairId,
+      volume,
+      expirationTimestamp,
+    ] = event.data;
 
-		// Convert felts to string
-		const publisherName = escapeInvalidCharacters(
-			shortString.decodeShortString(publisher)
-		);
-		const sourceName = escapeInvalidCharacters(
-			shortString.decodeShortString(source)
-		);
-		const pairIdName = escapeInvalidCharacters(
-			shortString.decodeShortString(pairId)
-		);
+    // Convert felts to string
+    const publisherName = escapeInvalidCharacters(
+      shortString.decodeShortString(publisher),
+    );
+    const sourceName = escapeInvalidCharacters(
+      shortString.decodeShortString(source),
+    );
+    const pairIdName = escapeInvalidCharacters(
+      shortString.decodeShortString(pairId),
+    );
 
-		// Convert to snake_case because it works better with postgres.
-		return {
-			network: "starknet-goerli",
-			pair_id: pairIdName,
-			data_id: dataId,
-			block_hash: blockHash,
-			block_number: +blockNumber,
-			block_timestamp: timestamp,
-			transaction_hash: transactionHash,
-			price: +price,
-			timestamp: new Date(Number(entryTimestamp) * 1000).toISOString(),
-			publisher: publisherName,
-			source: sourceName,
-			volume: +volume,
-			expiration_timestamp: new Date(Number(expirationTimestamp)).toISOString(),
-		};
-	});
+    // Convert to snake_case because it works better with postgres.
+    return {
+      network: "starknet-goerli",
+      pair_id: pairIdName,
+      data_id: dataId,
+      block_hash: blockHash,
+      block_number: +blockNumber,
+      block_timestamp: timestamp,
+      transaction_hash: transactionHash,
+      price: +price,
+      timestamp: new Date(Number(entryTimestamp) * 1000).toISOString(),
+      publisher: publisherName,
+      source: sourceName,
+      volume: +volume,
+      expiration_timestamp: new Date(Number(expirationTimestamp)).toISOString(),
+    };
+  });
 }
 
 // Configure indexer for streaming Starknet Goerli data starting at the specified block.
 export const config = {
-	streamUrl: "https://goerli.starknet.a5a.ch",
-	startingBlock: 881742,
-	network: "starknet",
-	filter,
-	sinkType: "postgres",
-	sinkOptions: {
-		// Send data as returned by `transform`.
-		// When `raw = false`, the data is sent together with the starting and end cursor.
-		raw: true,
-	},
+  streamUrl: "https://goerli.starknet.a5a.ch",
+  startingBlock: 881742,
+  network: "starknet",
+  filter,
+  sinkType: "postgres",
+  sinkOptions: {
+    // Send data as returned by `transform`.
+    // When `raw = false`, the data is sent together with the starting and end cursor.
+    raw: true,
+  },
 };
 
 // Transform each block using the function defined in starknet.js.

--- a/examples/pragma/testnet/goerli-script-spot.js
+++ b/examples/pragma/testnet/goerli-script-spot.js
@@ -1,73 +1,73 @@
 import { hash, shortString } from "https://esm.run/starknet@5.14";
 
 const filter = {
-	// Only request header if any event matches.
-	header: {
-		weak: true,
-	},
-	events: [
-		{
-			fromAddress:
-				"0x6df335982dddce41008e4c03f2546fa27276567b5274c7d0c1262f3c2b5d167",
-			keys: [hash.getSelectorFromName("SubmittedSpotEntry")],
-		},
-	],
+  // Only request header if any event matches.
+  header: {
+    weak: true,
+  },
+  events: [
+    {
+      fromAddress:
+        "0x6df335982dddce41008e4c03f2546fa27276567b5274c7d0c1262f3c2b5d167",
+      keys: [hash.getSelectorFromName("SubmittedSpotEntry")],
+    },
+  ],
 };
 
 function escapeInvalidCharacters(str) {
-	return str.replace(/^[\x00-\x1F]+/, "");
+  return str.replace(/^[\x00-\x1F]+/, "");
 }
 
 function decodeTransfersInBlock({ header, events }) {
-	const { blockNumber, blockHash, timestamp } = header;
-	return events.map(({ event, receipt }) => {
-		const { transactionHash } = receipt;
-		const dataId = `${transactionHash}_${event.index}`;
+  const { blockNumber, blockHash, timestamp } = header;
+  return events.map(({ event, receipt }) => {
+    const { transactionHash } = receipt;
+    const dataId = `${transactionHash}_${event.index}`;
 
-		const [entryTimestamp, source, publisher, price, pairId, volume] =
-			event.data;
+    const [entryTimestamp, source, publisher, price, pairId, volume] =
+      event.data;
 
-		// Convert felts to string
-		const publisherName = escapeInvalidCharacters(
-			shortString.decodeShortString(publisher)
-		);
-		const sourceName = escapeInvalidCharacters(
-			shortString.decodeShortString(source)
-		);
-		const pairIdName = escapeInvalidCharacters(
-			shortString.decodeShortString(pairId)
-		);
+    // Convert felts to string
+    const publisherName = escapeInvalidCharacters(
+      shortString.decodeShortString(publisher),
+    );
+    const sourceName = escapeInvalidCharacters(
+      shortString.decodeShortString(source),
+    );
+    const pairIdName = escapeInvalidCharacters(
+      shortString.decodeShortString(pairId),
+    );
 
-		// Convert to snake_case because it works better with postgres.
-		return {
-			network: "starknet-goerli",
-			pair_id: pairIdName,
-			data_id: dataId,
-			block_hash: blockHash,
-			block_number: +blockNumber,
-			block_timestamp: timestamp,
-			transaction_hash: transactionHash,
-			price: +price,
-			timestamp: new Date(Number(entryTimestamp) * 1000).toISOString(),
-			publisher: publisherName,
-			source: sourceName,
-			volume: +volume,
-		};
-	});
+    // Convert to snake_case because it works better with postgres.
+    return {
+      network: "starknet-goerli",
+      pair_id: pairIdName,
+      data_id: dataId,
+      block_hash: blockHash,
+      block_number: +blockNumber,
+      block_timestamp: timestamp,
+      transaction_hash: transactionHash,
+      price: +price,
+      timestamp: new Date(Number(entryTimestamp) * 1000).toISOString(),
+      publisher: publisherName,
+      source: sourceName,
+      volume: +volume,
+    };
+  });
 }
 
 // Configure indexer for streaming Starknet Goerli data starting at the specified block.
 export const config = {
-	streamUrl: "https://goerli.starknet.a5a.ch",
-	startingBlock: 881742,
-	network: "starknet",
-	filter,
-	sinkType: "postgres",
-	sinkOptions: {
-		// Send data as returned by `transform`.
-		// When `raw = false`, the data is sent together with the starting and end cursor.
-		raw: true,
-	},
+  streamUrl: "https://goerli.starknet.a5a.ch",
+  startingBlock: 881742,
+  network: "starknet",
+  filter,
+  sinkType: "postgres",
+  sinkOptions: {
+    // Send data as returned by `transform`.
+    // When `raw = false`, the data is sent together with the starting and end cursor.
+    raw: true,
+  },
 };
 
 // Transform each block using the function defined in starknet.js.

--- a/examples/pragma/testnet/vrf-testnet-script-requests.js
+++ b/examples/pragma/testnet/vrf-testnet-script-requests.js
@@ -6,95 +6,95 @@
  */
 
 const fromAddress =
-	"0x693d551265f0be7ccb3c869c64b5920929caaf486497788d43cb37dd17d6be6";
+  "0x693d551265f0be7ccb3c869c64b5920929caaf486497788d43cb37dd17d6be6";
 
 // RandomnessRequest event selector
 const requestSelector =
-	"0x00e3e1c077138abb6d570b1a7ba425f5479b12f50a78a72be680167d4cf79c48";
+  "0x00e3e1c077138abb6d570b1a7ba425f5479b12f50a78a72be680167d4cf79c48";
 
 // RandomnessStatusChange event selector
 const statusChangeSelector =
-	"0x015510b399942790499934b72bc68b883f0905dee5da5aa36e489c9ffb096b8c";
+  "0x015510b399942790499934b72bc68b883f0905dee5da5aa36e489c9ffb096b8c";
 
 export const config = {
-	streamUrl: "https://goerli.starknet.a5a.ch",
-	startingBlock: 908_100,
-	network: "starknet",
-	batchSize: 1,
-	finality: "DATA_STATUS_ACCEPTED",
-	filter: {
-		header: { weak: true },
-		events: [
-			{
-				fromAddress,
-				keys: [requestSelector],
-				includeTransaction: true,
-				includeReceipt: false,
-			},
-			{
-				fromAddress,
-				keys: [statusChangeSelector],
-				includeTransaction: true,
-				includeReceipt: false,
-			},
-		],
-	},
-	sinkType: "postgres",
-	sinkOptions: {
-		tableName: "vrf_requests",
-		entityMode: true,
-	},
+  streamUrl: "https://goerli.starknet.a5a.ch",
+  startingBlock: 908_100,
+  network: "starknet",
+  batchSize: 1,
+  finality: "DATA_STATUS_ACCEPTED",
+  filter: {
+    header: { weak: true },
+    events: [
+      {
+        fromAddress,
+        keys: [requestSelector],
+        includeTransaction: true,
+        includeReceipt: false,
+      },
+      {
+        fromAddress,
+        keys: [statusChangeSelector],
+        includeTransaction: true,
+        includeReceipt: false,
+      },
+    ],
+  },
+  sinkType: "postgres",
+  sinkOptions: {
+    tableName: "vrf_requests",
+    entityMode: true,
+  },
 };
 
 export default function transform({ header, events }) {
-	const { timestamp } = header;
-	return events.flatMap(({ event, transaction }) => {
-		if (event.keys[0] == requestSelector) {
-			// Initialize request entity.
-			const [
-				requestId,
-				callerAddress,
-				seed,
-				minimumBlockNumber,
-				callbackAddress,
-				callbackFeeLimit,
-				numWords,
-			] = event.data;
-			return {
-				insert: {
-					data_id: `${transaction.meta.hash}_${event.index}`,
-					network: "starknet-goerli",
-					request_id: +requestId,
-					seed: +seed,
-					created_at: timestamp,
-					created_at_tx: transaction.meta.hash,
-					minimum_block_number: +minimumBlockNumber,
-					callback_address: callbackAddress,
-					callback_fee_limit: +callbackFeeLimit,
-					num_words: +numWords,
-					requestor_address: callerAddress,
-					updated_at: timestamp,
-					updated_at_tx: transaction.meta.hash,
-					status: 0,
-				},
-			};
-		} else if (event.keys[0] == statusChangeSelector) {
-			// Update request entity.
-			const requestId = event.data[1];
-			const status = event.data[2];
-			return {
-				entity: {
-					request_id: +requestId,
-				},
-				update: {
-					status: +status,
-					updated_at: timestamp,
-					updated_at_tx: transaction.meta.hash,
-				},
-			};
-		} else {
-			// Do nothing.
-			return [];
-		}
-	});
+  const { timestamp } = header;
+  return events.flatMap(({ event, transaction }) => {
+    if (event.keys[0] == requestSelector) {
+      // Initialize request entity.
+      const [
+        requestId,
+        callerAddress,
+        seed,
+        minimumBlockNumber,
+        callbackAddress,
+        callbackFeeLimit,
+        numWords,
+      ] = event.data;
+      return {
+        insert: {
+          data_id: `${transaction.meta.hash}_${event.index}`,
+          network: "starknet-goerli",
+          request_id: +requestId,
+          seed: +seed,
+          created_at: timestamp,
+          created_at_tx: transaction.meta.hash,
+          minimum_block_number: +minimumBlockNumber,
+          callback_address: callbackAddress,
+          callback_fee_limit: +callbackFeeLimit,
+          num_words: +numWords,
+          requestor_address: callerAddress,
+          updated_at: timestamp,
+          updated_at_tx: transaction.meta.hash,
+          status: 0,
+        },
+      };
+    } else if (event.keys[0] == statusChangeSelector) {
+      // Update request entity.
+      const requestId = event.data[1];
+      const status = event.data[2];
+      return {
+        entity: {
+          request_id: +requestId,
+        },
+        update: {
+          status: +status,
+          updated_at: timestamp,
+          updated_at_tx: transaction.meta.hash,
+        },
+      };
+    } else {
+      // Do nothing.
+      return [];
+    }
+  });
 }

--- a/migrations/2023-12-21-135159_add_indexer_status_port/down.sql
+++ b/migrations/2023-12-21-135159_add_indexer_status_port/down.sql
@@ -1,0 +1,1 @@
+-- This file should undo anything in `up.sql`

--- a/migrations/2023-12-21-135159_add_indexer_status_port/down.sql
+++ b/migrations/2023-12-21-135159_add_indexer_status_port/down.sql
@@ -1,1 +1,3 @@
 -- This file should undo anything in `up.sql`
+ALTER TABLE indexers
+DROP COLUMN status_server_port;

--- a/migrations/2023-12-21-135159_add_indexer_status_port/up.sql
+++ b/migrations/2023-12-21-135159_add_indexer_status_port/up.sql
@@ -1,0 +1,3 @@
+-- Your SQL goes here
+ALTER TABLE indexers
+ADD COLUMN status_server_port SMALLINT DEFAULT 1234;

--- a/migrations/2023-12-21-135159_add_indexer_status_port/up.sql
+++ b/migrations/2023-12-21-135159_add_indexer_status_port/up.sql
@@ -1,3 +1,3 @@
 -- Your SQL goes here
 ALTER TABLE indexers
-ADD COLUMN status_server_port SMALLINT DEFAULT 1234;
+ADD COLUMN status_server_port INTEGER DEFAULT 1234;

--- a/src/domain/models/indexer.rs
+++ b/src/domain/models/indexer.rs
@@ -39,6 +39,7 @@ pub struct IndexerModel {
     pub process_id: Option<i64>,
     pub target_url: Option<String>,
     pub table_name: Option<String>,
+    pub status_server_port: Option<i16>,
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/src/domain/models/indexer.rs
+++ b/src/domain/models/indexer.rs
@@ -12,6 +12,7 @@ use strum_macros::{Display, EnumString};
 use uuid::Uuid;
 
 use crate::domain::models::types::AxumErrorResponse;
+use crate::grpc::apibara_sink_v1::GetStatusResponse;
 use crate::infra::errors::InfraError;
 
 #[derive(Clone, Default, Debug, PartialEq, EnumString, Serialize, Deserialize, Display, Copy)]
@@ -40,6 +41,28 @@ pub struct IndexerModel {
     pub target_url: Option<String>,
     pub table_name: Option<String>,
     pub status_server_port: Option<i16>,
+}
+
+#[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
+pub struct IndexerServerStatus {
+    pub status: i32,
+    pub starting_block: Option<u64>,
+    pub current_block: Option<u64>,
+    pub head_block: Option<u64>,
+    #[serde(rename = "reason")]
+    pub reason_: Option<String>,
+}
+
+impl From<GetStatusResponse> for IndexerServerStatus {
+    fn from(value: GetStatusResponse) -> Self {
+        Self {
+            status: value.status,
+            starting_block: value.starting_block,
+            current_block: value.current_block,
+            head_block: value.head_block,
+            reason_: value.reason,
+        }
+    }
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -78,6 +101,12 @@ pub enum IndexerError {
     InvalidIndexerType(String),
     #[error("failed to serialize {0}")]
     FailedToSerialize(String),
+    #[error("indexer status server port not found")]
+    IndexerStatusServerPortNotFound,
+    #[error("failed to connect to gRPC server")]
+    FailedToConnectGRPC(tonic::transport::Error),
+    #[error("gRPC request failed")]
+    GRPCRequestFailed(tonic::Status),
 }
 
 impl From<diesel::result::Error> for IndexerError {

--- a/src/domain/models/indexer.rs
+++ b/src/domain/models/indexer.rs
@@ -40,7 +40,7 @@ pub struct IndexerModel {
     pub process_id: Option<i64>,
     pub target_url: Option<String>,
     pub table_name: Option<String>,
-    pub status_server_port: Option<i16>,
+    pub status_server_port: Option<i32>,
 }
 
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]

--- a/src/grpc/apibara_sink_v1.rs
+++ b/src/grpc/apibara_sink_v1.rs
@@ -1,0 +1,302 @@
+/// Request for the `GetStatus` method.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetStatusRequest {}
+/// Response for the `GetStatus` method.
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetStatusResponse {
+    /// The status of the sink.
+    #[prost(enumeration = "SinkStatus", tag = "1")]
+    pub status: i32,
+    /// The starting block.
+    #[prost(uint64, optional, tag = "2")]
+    pub starting_block: ::core::option::Option<u64>,
+    /// The current block.
+    #[prost(uint64, optional, tag = "3")]
+    pub current_block: ::core::option::Option<u64>,
+    /// The current head of the chain.
+    #[prost(uint64, optional, tag = "4")]
+    pub head_block: ::core::option::Option<u64>,
+    /// The reason why the sink is not running.
+    #[prost(string, optional, tag = "5")]
+    pub reason: ::core::option::Option<::prost::alloc::string::String>,
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum SinkStatus {
+    Unknown = 0,
+    /// The sink is running.
+    Running = 1,
+    /// The sink has errored.
+    Errored = 2,
+}
+impl SinkStatus {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            SinkStatus::Unknown => "SINK_STATUS_UNKNOWN",
+            SinkStatus::Running => "SINK_STATUS_RUNNING",
+            SinkStatus::Errored => "SINK_STATUS_ERRORED",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "SINK_STATUS_UNKNOWN" => Some(Self::Unknown),
+            "SINK_STATUS_RUNNING" => Some(Self::Running),
+            "SINK_STATUS_ERRORED" => Some(Self::Errored),
+            _ => None,
+        }
+    }
+}
+/// Generated client implementations.
+pub mod status_client {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::http::Uri;
+    use tonic::codegen::*;
+    #[derive(Debug, Clone)]
+    pub struct StatusClient<T> {
+        inner: tonic::client::Grpc<T>,
+    }
+    impl StatusClient<tonic::transport::Channel> {
+        /// Attempt to create a new client by connecting to a given endpoint.
+        pub async fn connect<D>(dst: D) -> Result<Self, tonic::transport::Error>
+        where
+            D: TryInto<tonic::transport::Endpoint>,
+            D::Error: Into<StdError>,
+        {
+            let conn = tonic::transport::Endpoint::new(dst)?.connect().await?;
+            Ok(Self::new(conn))
+        }
+    }
+    impl<T> StatusClient<T>
+    where
+        T: tonic::client::GrpcService<tonic::body::BoxBody>,
+        T::Error: Into<StdError>,
+        T::ResponseBody: Body<Data = Bytes> + Send + 'static,
+        <T::ResponseBody as Body>::Error: Into<StdError> + Send,
+    {
+        pub fn new(inner: T) -> Self {
+            let inner = tonic::client::Grpc::new(inner);
+            Self { inner }
+        }
+        pub fn with_origin(inner: T, origin: Uri) -> Self {
+            let inner = tonic::client::Grpc::with_origin(inner, origin);
+            Self { inner }
+        }
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> StatusClient<InterceptedService<T, F>>
+        where
+            F: tonic::service::Interceptor,
+            T::ResponseBody: Default,
+            T: tonic::codegen::Service<
+                    http::Request<tonic::body::BoxBody>,
+                    Response = http::Response<<T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody>,
+                >,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error: Into<StdError> + Send + Sync,
+        {
+            StatusClient::new(InterceptedService::new(inner, interceptor))
+        }
+        /// Compress requests with the given encoding.
+        ///
+        /// This requires the server to support it otherwise it might respond with an
+        /// error.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.send_compressed(encoding);
+            self
+        }
+        /// Enable decompressing responses.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.inner = self.inner.accept_compressed(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_decoding_message_size(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.inner = self.inner.max_encoding_message_size(limit);
+            self
+        }
+        /// Get Sink status.
+        pub async fn get_status(
+            &mut self,
+            request: impl tonic::IntoRequest<super::GetStatusRequest>,
+        ) -> std::result::Result<tonic::Response<super::GetStatusResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(tonic::Code::Unknown, format!("Service was not ready: {}", e.into()))
+            })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static("/apibara.sink.v1.Status/GetStatus");
+            let mut req = request.into_request();
+            req.extensions_mut().insert(GrpcMethod::new("apibara.sink.v1.Status", "GetStatus"));
+            self.inner.unary(req, path, codec).await
+        }
+    }
+}
+/// Generated server implementations.
+pub mod status_server {
+    #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
+    use tonic::codegen::*;
+    /// Generated trait containing gRPC methods that should be implemented for use with
+    /// StatusServer.
+    #[async_trait]
+    pub trait Status: Send + Sync + 'static {
+        /// Get Sink status.
+        async fn get_status(
+            &self,
+            request: tonic::Request<super::GetStatusRequest>,
+        ) -> std::result::Result<tonic::Response<super::GetStatusResponse>, tonic::Status>;
+    }
+    #[derive(Debug)]
+    pub struct StatusServer<T: Status> {
+        inner: _Inner<T>,
+        accept_compression_encodings: EnabledCompressionEncodings,
+        send_compression_encodings: EnabledCompressionEncodings,
+        max_decoding_message_size: Option<usize>,
+        max_encoding_message_size: Option<usize>,
+    }
+    struct _Inner<T>(Arc<T>);
+    impl<T: Status> StatusServer<T> {
+        pub fn new(inner: T) -> Self {
+            Self::from_arc(Arc::new(inner))
+        }
+        pub fn from_arc(inner: Arc<T>) -> Self {
+            let inner = _Inner(inner);
+            Self {
+                inner,
+                accept_compression_encodings: Default::default(),
+                send_compression_encodings: Default::default(),
+                max_decoding_message_size: None,
+                max_encoding_message_size: None,
+            }
+        }
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        where
+            F: tonic::service::Interceptor,
+        {
+            InterceptedService::new(Self::new(inner), interceptor)
+        }
+        /// Enable decompressing requests with the given encoding.
+        #[must_use]
+        pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.accept_compression_encodings.enable(encoding);
+            self
+        }
+        /// Compress responses with the given encoding, if the client supports it.
+        #[must_use]
+        pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
+            self.send_compression_encodings.enable(encoding);
+            self
+        }
+        /// Limits the maximum size of a decoded message.
+        ///
+        /// Default: `4MB`
+        #[must_use]
+        pub fn max_decoding_message_size(mut self, limit: usize) -> Self {
+            self.max_decoding_message_size = Some(limit);
+            self
+        }
+        /// Limits the maximum size of an encoded message.
+        ///
+        /// Default: `usize::MAX`
+        #[must_use]
+        pub fn max_encoding_message_size(mut self, limit: usize) -> Self {
+            self.max_encoding_message_size = Some(limit);
+            self
+        }
+    }
+    impl<T, B> tonic::codegen::Service<http::Request<B>> for StatusServer<T>
+    where
+        T: Status,
+        B: Body + Send + 'static,
+        B::Error: Into<StdError> + Send + 'static,
+    {
+        type Response = http::Response<tonic::body::BoxBody>;
+        type Error = std::convert::Infallible;
+        type Future = BoxFuture<Self::Response, Self::Error>;
+        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<std::result::Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+        fn call(&mut self, req: http::Request<B>) -> Self::Future {
+            let inner = self.inner.clone();
+            match req.uri().path() {
+                "/apibara.sink.v1.Status/GetStatus" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetStatusSvc<T: Status>(pub Arc<T>);
+                    impl<T: Status> tonic::server::UnaryService<super::GetStatusRequest> for GetStatusSvc<T> {
+                        type Response = super::GetStatusResponse;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        fn call(&mut self, request: tonic::Request<super::GetStatusRequest>) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move { (*inner).get_status(request).await };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = GetStatusSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(accept_compression_encodings, send_compression_encodings)
+                            .apply_max_message_size_config(max_decoding_message_size, max_encoding_message_size);
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                _ => Box::pin(async move {
+                    Ok(http::Response::builder()
+                        .status(200)
+                        .header("grpc-status", "12")
+                        .header("content-type", "application/grpc")
+                        .body(empty_body())
+                        .unwrap())
+                }),
+            }
+        }
+    }
+    impl<T: Status> Clone for StatusServer<T> {
+        fn clone(&self) -> Self {
+            let inner = self.inner.clone();
+            Self {
+                inner,
+                accept_compression_encodings: self.accept_compression_encodings,
+                send_compression_encodings: self.send_compression_encodings,
+                max_decoding_message_size: self.max_decoding_message_size,
+                max_encoding_message_size: self.max_encoding_message_size,
+            }
+        }
+    }
+    impl<T: Status> Clone for _Inner<T> {
+        fn clone(&self) -> Self {
+            Self(Arc::clone(&self.0))
+        }
+    }
+    impl<T: std::fmt::Debug> std::fmt::Debug for _Inner<T> {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "{:?}", self.0)
+        }
+    }
+    impl<T: Status> tonic::server::NamedService for StatusServer<T> {
+        const NAME: &'static str = "apibara.sink.v1.Status";
+    }
+}

--- a/src/grpc/mod.rs
+++ b/src/grpc/mod.rs
@@ -1,0 +1,1 @@
+pub mod apibara_sink_v1;

--- a/src/handlers/indexers/create_indexer.rs
+++ b/src/handlers/indexers/create_indexer.rs
@@ -49,7 +49,7 @@ impl CreateIndexerRequest {
         true
     }
 
-    /// Set a random available port for the GRPC status server
+    /// Set a random available port for the gRPC status server
     fn set_random_port(&mut self) {
         // Bind to a random port
         if let Ok(listener) = TcpListener::bind("localhost:0") {

--- a/src/handlers/indexers/create_indexer.rs
+++ b/src/handlers/indexers/create_indexer.rs
@@ -25,7 +25,7 @@ struct CreateIndexerRequest {
     data: Bytes,
     table_name: Option<String>,
     indexer_type: IndexerType,
-    status_server_port: i16,
+    status_server_port: i32,
 }
 
 impl CreateIndexerRequest {
@@ -52,10 +52,10 @@ impl CreateIndexerRequest {
     /// Set a random available port for the gRPC status server
     fn set_random_port(&mut self) {
         // Bind to a random port
-        if let Ok(listener) = TcpListener::bind("localhost:0") {
+        if let Ok(listener) = TcpListener::bind("127.0.0.1:0") {
             if let Ok(addr) = listener.local_addr() {
                 // Set the found port
-                self.status_server_port = addr.port() as i16;
+                self.status_server_port = addr.port() as i32;
             }
         }
     }

--- a/src/handlers/indexers/get_indexer.rs
+++ b/src/handlers/indexers/get_indexer.rs
@@ -2,7 +2,9 @@ use axum::extract::State;
 use axum::Json;
 use uuid::Uuid;
 
-use crate::domain::models::indexer::{IndexerError, IndexerModel};
+use crate::domain::models::indexer::{IndexerError, IndexerModel, IndexerServerStatus};
+use crate::grpc::apibara_sink_v1::status_client::StatusClient;
+use crate::grpc::apibara_sink_v1::GetStatusRequest;
 use crate::infra::repositories::indexer_repository::{IndexerRepository, Repository};
 use crate::utils::PathExtractor;
 use crate::AppState;
@@ -20,9 +22,24 @@ pub async fn get_indexer(
 pub async fn get_indexer_status(
     State(state): State<AppState>,
     PathExtractor(id): PathExtractor<Uuid>,
-) -> Result<Json<IndexerModel>, IndexerError> {
+) -> Result<Json<IndexerServerStatus>, IndexerError> {
     let repository = IndexerRepository::new(&state.pool);
     let indexer_model = repository.get(id).await.map_err(IndexerError::InfraError)?;
 
-    Ok(Json(indexer_model))
+    let server_port = indexer_model.status_server_port.ok_or(IndexerError::IndexerStatusServerPortNotFound)?;
+
+    // Create a gRPC client
+    let endpoint = format!("http://localhost:{}", server_port);
+    let mut client = StatusClient::connect(endpoint).await.map_err(IndexerError::FailedToConnectGRPC)?;
+
+    // Create a GetStatusRequest
+    let request = tonic::Request::new(GetStatusRequest {});
+
+    // Fetch the status
+    let response = client.get_status(request).await.map_err(IndexerError::GRPCRequestFailed)?;
+
+    // Process the response
+    let status_response = response.into_inner();
+
+    Ok(Json(status_response.into()))
 }

--- a/src/handlers/indexers/get_indexer.rs
+++ b/src/handlers/indexers/get_indexer.rs
@@ -16,3 +16,13 @@ pub async fn get_indexer(
 
     Ok(Json(indexer_model))
 }
+
+pub async fn get_indexer_status(
+    State(state): State<AppState>,
+    PathExtractor(id): PathExtractor<Uuid>,
+) -> Result<Json<IndexerModel>, IndexerError> {
+    let repository = IndexerRepository::new(&state.pool);
+    let indexer_model = repository.get(id).await.map_err(IndexerError::InfraError)?;
+
+    Ok(Json(indexer_model))
+}

--- a/src/handlers/indexers/indexer_types/mod.rs
+++ b/src/handlers/indexers/indexer_types/mod.rs
@@ -36,6 +36,8 @@ pub trait Indexer {
         let etcd_url = get_environment_variable("APIBARA_ETCD_URL");
 
         let indexer_id = indexer.id.to_string();
+        let status_server_address = format!("0.0.0.0:{port}", port = indexer.status_server_port.unwrap_or(1234));
+
         let mut args = vec![
             "run",
             script_path.as_str(),
@@ -45,6 +47,8 @@ pub trait Indexer {
             etcd_url.as_str(),
             "--sink-id",
             indexer_id.as_str(),
+            "--status-server-address",
+            status_server_address.as_str(),
         ];
         args.extend_from_slice(extra_args);
 
@@ -205,6 +209,7 @@ mod tests {
             status: IndexerStatus::Created,
             target_url: Some("https://example.com".to_string()),
             table_name: None,
+            status_server_port: Some(1234),
         };
 
         // clear the sqs queue

--- a/src/infra/db/schema.rs
+++ b/src/infra/db/schema.rs
@@ -38,7 +38,4 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(
-    indexers,
-    spot_entry,
-);
+diesel::allow_tables_to_appear_in_same_query!(indexers, spot_entry,);

--- a/src/infra/db/schema.rs
+++ b/src/infra/db/schema.rs
@@ -5,9 +5,37 @@ diesel::table! {
         id -> Uuid,
         status -> Varchar,
         #[sql_name = "type"]
-        indexer_type -> Varchar,
+        type_ -> Varchar,
         process_id -> Nullable<Int8>,
         target_url -> Nullable<Varchar>,
         table_name -> Nullable<Varchar>,
+        status_server_port -> Nullable<Int2>,
     }
 }
+
+diesel::table! {
+    spot_entry (data_id) {
+        #[max_length = 255]
+        network -> Nullable<Varchar>,
+        #[max_length = 255]
+        pair_id -> Nullable<Varchar>,
+        #[max_length = 255]
+        data_id -> Varchar,
+        #[max_length = 255]
+        block_hash -> Nullable<Varchar>,
+        block_number -> Nullable<Int8>,
+        block_timestamp -> Nullable<Timestamp>,
+        #[max_length = 255]
+        transaction_hash -> Nullable<Varchar>,
+        price -> Nullable<Numeric>,
+        timestamp -> Nullable<Timestamp>,
+        #[max_length = 255]
+        publisher -> Nullable<Varchar>,
+        #[max_length = 255]
+        source -> Nullable<Varchar>,
+        volume -> Nullable<Numeric>,
+        _cursor -> Nullable<Int8>,
+    }
+}
+
+diesel::allow_tables_to_appear_in_same_query!(indexers, spot_entry,);

--- a/src/infra/db/schema.rs
+++ b/src/infra/db/schema.rs
@@ -9,7 +9,7 @@ diesel::table! {
         process_id -> Nullable<Int8>,
         target_url -> Nullable<Varchar>,
         table_name -> Nullable<Varchar>,
-        status_server_port -> Nullable<Int2>,
+        status_server_port -> Nullable<Int4>,
     }
 }
 
@@ -38,4 +38,7 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(indexers, spot_entry,);
+diesel::allow_tables_to_appear_in_same_query!(
+    indexers,
+    spot_entry,
+);

--- a/src/infra/repositories/indexer_repository.rs
+++ b/src/infra/repositories/indexer_repository.rs
@@ -18,10 +18,11 @@ use crate::infra::errors::InfraError;
 pub struct IndexerDb {
     pub id: Uuid,
     pub status: String,
-    pub indexer_type: String,
+    pub type_: String,
     pub process_id: Option<i64>,
     pub target_url: Option<String>,
     pub table_name: Option<String>,
+    pub status_server_port: Option<i16>,
 }
 
 #[derive(Deserialize)]
@@ -34,9 +35,10 @@ pub struct IndexerFilter {
 pub struct NewIndexerDb {
     pub id: Uuid,
     pub status: String,
-    pub indexer_type: String,
+    pub type_: String,
     pub target_url: Option<String>,
     pub table_name: Option<String>,
+    pub status_server_port: Option<i16>,
 }
 
 #[derive(Deserialize, Insertable)]
@@ -183,10 +185,11 @@ impl TryFrom<NewIndexerDb> for IndexerModel {
         let model = IndexerDb {
             id: value.id,
             status: value.status,
-            indexer_type: value.indexer_type,
+            type_: value.type_,
             target_url: value.target_url,
             process_id: None,
             table_name: value.table_name,
+            status_server_port: value.status_server_port,
         }
         .try_into()?;
         Ok(model)
@@ -200,9 +203,10 @@ impl TryFrom<IndexerDb> for IndexerModel {
             id: value.id,
             status: IndexerStatus::from_str(value.status.as_str())?,
             process_id: value.process_id,
-            indexer_type: IndexerType::from_str(value.indexer_type.as_str())?,
+            indexer_type: IndexerType::from_str(value.type_.as_str())?,
             target_url: value.target_url,
             table_name: value.table_name,
+            status_server_port: value.status_server_port,
         };
         Ok(model)
     }
@@ -234,10 +238,11 @@ mod tests {
         let indexer_db = IndexerDb {
             id,
             status: status.to_string(),
-            indexer_type: indexer_type.to_string(),
+            type_: indexer_type.to_string(),
             process_id,
             target_url: Some(target_url.to_string()),
             table_name: Some(table_name.into()),
+            status_server_port: Some(1234),
         };
 
         let indexer_model: Result<IndexerModel, ParseError> = indexer_db.try_into();
@@ -273,10 +278,11 @@ mod tests {
         let indexer_db = IndexerDb {
             id,
             status: status.to_string(),
-            indexer_type: indexer_type.to_string(),
+            type_: indexer_type.to_string(),
             process_id,
             target_url: Some(target_url.to_string()),
             table_name: Some(table_name.into()),
+            status_server_port: Some(1234),
         };
 
         let indexer_model: Result<IndexerModel, ParseError> = indexer_db.try_into();

--- a/src/infra/repositories/indexer_repository.rs
+++ b/src/infra/repositories/indexer_repository.rs
@@ -22,7 +22,7 @@ pub struct IndexerDb {
     pub process_id: Option<i64>,
     pub target_url: Option<String>,
     pub table_name: Option<String>,
-    pub status_server_port: Option<i16>,
+    pub status_server_port: Option<i32>,
 }
 
 #[derive(Deserialize)]
@@ -38,7 +38,7 @@ pub struct NewIndexerDb {
     pub type_: String,
     pub target_url: Option<String>,
     pub table_name: Option<String>,
-    pub status_server_port: Option<i16>,
+    pub status_server_port: Option<i32>,
 }
 
 #[derive(Deserialize, Insertable)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,9 @@ use crate::errors::internal_error;
 use crate::handlers::indexers::start_indexer::start_all_indexers;
 use crate::routes::app_router;
 
+/// gRPC clients
+mod grpc;
+
 /// Configuration of the service (AWS, DB, etc)
 mod config;
 /// Constants used accross the service

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -5,7 +5,7 @@ use axum::Router;
 
 use crate::handlers::global::health::health_check;
 use crate::handlers::indexers::create_indexer::create_indexer;
-use crate::handlers::indexers::get_indexer::get_indexer;
+use crate::handlers::indexers::get_indexer::{get_indexer, get_indexer_status};
 use crate::handlers::indexers::start_indexer::start_indexer_api;
 use crate::handlers::indexers::stop_indexer::stop_indexer;
 use crate::AppState;
@@ -27,6 +27,7 @@ fn indexers_routes(state: AppState) -> Router<AppState> {
         .route("/stop/:id", post(stop_indexer))
         .route("/start/:id", post(start_indexer_api))
         .route("/:id", get(get_indexer))
+        .route("status/:id", get(get_indexer_status))
         .with_state(state)
 }
 

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -27,7 +27,7 @@ fn indexers_routes(state: AppState) -> Router<AppState> {
         .route("/stop/:id", post(stop_indexer))
         .route("/start/:id", post(start_indexer_api))
         .route("/:id", get(get_indexer))
-        .route("status/:id", get(get_indexer_status))
+        .route("/status/:id", get(get_indexer_status))
         .with_state(state)
 }
 

--- a/src/tests/common/mod.rs
+++ b/src/tests/common/mod.rs
@@ -29,6 +29,7 @@ impl MockRepository {
                     process_id: None,
                     target_url: Some("https://example.com".to_string()),
                     table_name: None,
+                    status_server_port: None,
                 },
                 IndexerModel {
                     id: uuid::Uuid::new_v4(),
@@ -37,6 +38,7 @@ impl MockRepository {
                     process_id: Some(123),
                     target_url: Some("https://example.com".to_string()),
                     table_name: None,
+                    status_server_port: None,
                 },
                 IndexerModel {
                     id: uuid::Uuid::new_v4(),
@@ -45,6 +47,7 @@ impl MockRepository {
                     process_id: None,
                     target_url: Some("https://example.com".to_string()),
                     table_name: None,
+                    status_server_port: None,
                 },
                 IndexerModel {
                     id: uuid::Uuid::new_v4(),
@@ -53,6 +56,7 @@ impl MockRepository {
                     process_id: None,
                     target_url: Some("https://example.com".to_string()),
                     table_name: None,
+                    status_server_port: None,
                 },
                 IndexerModel {
                     id: uuid::Uuid::new_v4(),
@@ -61,6 +65,7 @@ impl MockRepository {
                     process_id: Some(123),
                     target_url: Some("https://example.com".to_string()),
                     table_name: None,
+                    status_server_port: None,
                 },
             ],
         }

--- a/src/tests/repository.rs
+++ b/src/tests/repository.rs
@@ -19,9 +19,10 @@ async fn test_get_indexer() {
         .insert(NewIndexerDb {
             id,
             status: "Created".to_string(),
-            indexer_type: "Webhook".to_string(),
+            type_: "Webhook".to_string(),
             target_url: Some("https://example.com".to_string()), // TODO: Mock webhook and test its behavior
             table_name: None,
+            status_server_port: None,
         })
         .await
         .unwrap();
@@ -49,9 +50,10 @@ async fn test_insert_indexer() {
         .insert(NewIndexerDb {
             id,
             status: "Created".to_string(),
-            indexer_type: "Webhook".to_string(),
+            type_: "Webhook".to_string(),
             target_url: Some("https://example.com".to_string()),
             table_name: None,
+            status_server_port: None,
         })
         .await
         .unwrap();
@@ -76,9 +78,10 @@ async fn test_update_status() {
         .insert(NewIndexerDb {
             id,
             status: "Created".to_string(),
-            indexer_type: "Webhook".to_string(),
+            type_: "Webhook".to_string(),
             target_url: Some("https://example.com".to_string()),
             table_name: None,
+            status_server_port: None,
         })
         .await
         .unwrap();
@@ -102,9 +105,10 @@ async fn test_update_status_and_process_id() {
         .insert(NewIndexerDb {
             id,
             status: "Created".to_string(),
-            indexer_type: "Webhook".to_string(),
+            type_: "Webhook".to_string(),
             target_url: Some("https://example.com".to_string()),
             table_name: None,
+            status_server_port: None,
         })
         .await
         .unwrap();
@@ -136,9 +140,10 @@ async fn test_get_all_indexers() {
             .insert(NewIndexerDb {
                 id,
                 status: "Created".to_string(),
-                indexer_type: "Webhook".to_string(),
+                type_: "Webhook".to_string(),
                 target_url: Some("https://example.com".to_string()),
                 table_name: None,
+                status_server_port: None,
             })
             .await
             .unwrap();
@@ -149,9 +154,10 @@ async fn test_get_all_indexers() {
         .insert(NewIndexerDb {
             id,
             status: "Running".to_string(),
-            indexer_type: "Webhook".to_string(),
+            type_: "Webhook".to_string(),
             target_url: Some("https://example.com".to_string()),
             table_name: None,
+            status_server_port: None,
         })
         .await
         .unwrap();


### PR DESCRIPTION
This PR adds the `/status/:id` route on the API.

When spinning up a new apibara indexer, you can specify an address for the gRPC status server.
The service assigns a random available port to every indexer it starts.
This port is then passed to the `run` command with the `--status-server-address` option.

Finally, one one want to query an indexer's status we simply query the indexer's status server through gRPC.