### PR TITLE
✨ /status/:table_name GET

### DIFF
--- a/src/routes.rs
+++ b/src/routes.rs
@@ -5,7 +5,7 @@ use axum::Router;
 
 use crate::handlers::global::health::health_check;
 use crate::handlers::indexers::create_indexer::create_indexer;
-use crate::handlers::indexers::get_indexer::{get_indexer, get_indexer_status};
+use crate::handlers::indexers::get_indexer::{get_indexer, get_indexer_status, get_indexer_status_by_table_name};
 use crate::handlers::indexers::start_indexer::start_indexer_api;
 use crate::handlers::indexers::stop_indexer::stop_indexer;
 use crate::AppState;
@@ -28,6 +28,7 @@ fn indexers_routes(state: AppState) -> Router<AppState> {
         .route("/start/:id", post(start_indexer_api))
         .route("/:id", get(get_indexer))
         .route("/status/:id", get(get_indexer_status))
+        .route("/status/table/:table_name", get(get_indexer_status_by_table_name))
         .with_state(state)
 }
 

--- a/src/tests/common/mod.rs
+++ b/src/tests/common/mod.rs
@@ -84,6 +84,10 @@ impl Repository for MockRepository {
         let indexer = self.indexers.iter().find(|indexer| indexer.id == id);
         if let Some(indexer) = indexer { Ok(indexer.clone()) } else { Err(InfraError::NotFound) }
     }
+    async fn get_by_table_name(&self, table_name: String) -> Result<IndexerModel, InfraError> {
+        let indexer = self.indexers.iter().find(|indexer| indexer.table_name == Some(table_name.clone()));
+        if let Some(indexer) = indexer { Ok(indexer.clone()) } else { Err(InfraError::NotFound) }
+    }
     async fn get_all(&self, filter: IndexerFilter) -> Result<Vec<IndexerModel>, InfraError> {
         // Get all indexers with status filter if provided
         let indexers = match filter.status {


### PR DESCRIPTION
Adds a new route to get an indexer status by its table name.
Will query in the DB for the first indexer that has the given table name and a status of `Running`.