### PR TITLE
fix: indexers set sender_address to NULL

### DIFF
--- a/examples/pragma/mainnet/mainnet-script-spot-checkpoint.js
+++ b/examples/pragma/mainnet/mainnet-script-spot-checkpoint.js
@@ -26,7 +26,7 @@ function decodeTransfersInBlock({ header, events }) {
     const transactionHash = transaction.meta.hash;
 
     const invoke_tx = transaction.invokeV1 ?? transaction.invokeV3;
-    const senderAddress = invoke_tx.sender_address;
+    const senderAddress = invoke_tx.senderAddress;
 
     const dataId = `${transactionHash}_${event.index ?? 0}`;
 

--- a/examples/pragma/testnet/sepolia-script-spot-checkpoint.js
+++ b/examples/pragma/testnet/sepolia-script-spot-checkpoint.js
@@ -26,7 +26,7 @@ function decodeTransfersInBlock({ header, events }) {
     const transactionHash = transaction.meta.hash;
 
     const invoke_tx = transaction.invokeV1 ?? transaction.invokeV3;
-    const senderAddress = invoke_tx.sender_address;
+    const senderAddress = invoke_tx.senderAddress;
 
     const dataId = `${transactionHash}_${event.index ?? 0}`;
 


### PR DESCRIPTION
## Updated

- quick fix - indexers scripts were setting the `sender_address` to NULL