### PR TITLE
feat: add delete endpoint

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   coverage:
     # sadly, for now we have to "rebuild" for the coverage
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     env:
       HOST: 0.0.0.0

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -95,6 +95,8 @@ jobs:
           awslocal sqs create-queue --queue-name indexer-service-stop-indexer
           awslocal sqs list-queues
 
+      - uses: Swatinem/rust-cache@v2
+
       - name: Clean workspace
         run: |
           cargo llvm-cov clean --workspace

--- a/examples/pragma/mainnet/mainnet-script-spot-checkpoint.js
+++ b/examples/pragma/mainnet/mainnet-script-spot-checkpoint.js
@@ -30,8 +30,13 @@ function decodeTransfersInBlock({ header, events }) {
 
     const dataId = `${transactionHash}_${event.index ?? 0}`;
 
-    const [pairId, checkpointTimestamp, price, aggregationMode, nbSourcesAggregated] =
-      event.data;
+    const [
+      pairId,
+      checkpointTimestamp,
+      price,
+      aggregationMode,
+      nbSourcesAggregated,
+    ] = event.data;
 
     // Convert felts to string
     const pairIdName = escapeInvalidCharacters(

--- a/examples/pragma/testnet/sepolia-script-spot-checkpoint.js
+++ b/examples/pragma/testnet/sepolia-script-spot-checkpoint.js
@@ -30,8 +30,13 @@ function decodeTransfersInBlock({ header, events }) {
 
     const dataId = `${transactionHash}_${event.index ?? 0}`;
 
-    const [pairId, checkpointTimestamp, price, aggregationMode, nbSourcesAggregated] =
-      event.data;
+    const [
+      pairId,
+      checkpointTimestamp,
+      price,
+      aggregationMode,
+      nbSourcesAggregated,
+    ] = event.data;
 
     // Convert felts to string
     const pairIdName = escapeInvalidCharacters(

--- a/src/handlers/indexers/delete_indexer.rs
+++ b/src/handlers/indexers/delete_indexer.rs
@@ -1,0 +1,23 @@
+use axum::extract::State;
+use uuid::Uuid;
+
+use crate::domain::models::indexer::{IndexerError, IndexerStatus};
+use crate::infra::repositories::indexer_repository::{IndexerRepository, Repository};
+use crate::utils::PathExtractor;
+use crate::AppState;
+
+pub async fn delete_indexer(
+    State(state): State<AppState>,
+    PathExtractor(id): PathExtractor<Uuid>,
+) -> Result<(), IndexerError> {
+    let mut repository = IndexerRepository::new(&state.pool);
+    let indexer_model = repository.get(id).await.map_err(IndexerError::InfraError)?;
+    match indexer_model.status {
+        IndexerStatus::Stopped => (),
+        _ => return Err(IndexerError::InvalidIndexerStatus(indexer_model.status)),
+    }
+
+    repository.delete(id).await.map_err(IndexerError::InfraError)?;
+
+    Ok(())
+}

--- a/src/handlers/indexers/mod.rs
+++ b/src/handlers/indexers/mod.rs
@@ -1,4 +1,5 @@
 pub mod create_indexer;
+pub mod delete_indexer;
 pub mod fail_indexer;
 pub mod get_indexer;
 mod indexer_types;

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -1,11 +1,12 @@
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
-use axum::routing::{get, post};
+use axum::routing::{delete, get, post};
 use axum::Router;
 use tower_http::cors::{Any, CorsLayer};
 
 use crate::handlers::global::health::health_check;
 use crate::handlers::indexers::create_indexer::create_indexer;
+use crate::handlers::indexers::delete_indexer::delete_indexer;
 use crate::handlers::indexers::get_indexer::{
     get_indexer, get_indexer_status, get_indexer_status_by_table_name, get_indexers,
 };
@@ -31,6 +32,7 @@ fn indexers_routes(state: AppState) -> Router<AppState> {
         .route("/indexers", get(get_indexers))
         .route("/stop/:id", post(stop_indexer))
         .route("/start/:id", post(start_indexer_api))
+        .route("/delete/:id", delete(delete_indexer))
         .route("/:id", get(get_indexer))
         .route("/status/:id", get(get_indexer_status))
         .route("/status/table/:table_name", get(get_indexer_status_by_table_name))

--- a/src/tests/common/mod.rs
+++ b/src/tests/common/mod.rs
@@ -80,6 +80,11 @@ impl Repository for MockRepository {
         self.indexers.push(indexer.clone());
         Ok(indexer)
     }
+    async fn delete(&mut self, id: Uuid) -> Result<(), InfraError> {
+        // Delete the indexer from the mock database
+        self.indexers.retain(|indexer| indexer.id != id);
+        Ok(())
+    }
     async fn get(&self, id: Uuid) -> Result<IndexerModel, InfraError> {
         let indexer = self.indexers.iter().find(|indexer| indexer.id == id);
         if let Some(indexer) = indexer { Ok(indexer.clone()) } else { Err(InfraError::NotFound) }

--- a/src/tests/common/utils.rs
+++ b/src/tests/common/utils.rs
@@ -152,7 +152,7 @@ pub async fn send_stop_indexer_request(client: Client<HttpConnector>, id: Uuid, 
 /// - id: The id of the indexer to stop
 /// - addr: The address of the server to send the request to
 pub async fn send_delete_indexer_request(client: Client<HttpConnector>, id: Uuid, addr: SocketAddr) -> Response<Body> {
-    let response = client
+    client
         .request(
             Request::builder()
                 .method(http::Method::DELETE)
@@ -161,8 +161,7 @@ pub async fn send_delete_indexer_request(client: Client<HttpConnector>, id: Uuid
                 .unwrap(),
         )
         .await
-        .unwrap();
-    response
+        .unwrap()
 }
 
 /// Asserts that a queue contains a message which has a body equal to the

--- a/src/tests/common/utils.rs
+++ b/src/tests/common/utils.rs
@@ -146,6 +146,25 @@ pub async fn send_stop_indexer_request(client: Client<HttpConnector>, id: Uuid, 
     assert_eq!(response.status(), StatusCode::OK);
 }
 
+/// Sends a request to stop the indexer with the specified script path.
+/// Arguments
+/// - client: The hyper client to use to send the request
+/// - id: The id of the indexer to stop
+/// - addr: The address of the server to send the request to
+pub async fn send_delete_indexer_request(client: Client<HttpConnector>, id: Uuid, addr: SocketAddr) -> Response<Body> {
+    let response = client
+        .request(
+            Request::builder()
+                .method(http::Method::DELETE)
+                .uri(format!("http://{}/v1/indexers/delete/{}", addr, id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    response
+}
+
 /// Asserts that a queue contains a message which has a body equal to the
 /// id of the specified indexer
 pub async fn assert_queue_contains_message_with_indexer_id(queue_url: &str, body: String) {


### PR DESCRIPTION
Solves #58 

## Changes
- Adds a new `/delete` endpoint that deletes the indexer in DB given its id, only if its status is `STOPPED`
- Adds corresponding tests