### PR TITLE
feat: add connection_string param 

### DIFF
--- a/migrations/2024-11-24-191420_add_indexer_custom_connection_string/down.sql
+++ b/migrations/2024-11-24-191420_add_indexer_custom_connection_string/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+ALTER TABLE indexers DROP COLUMN custom_connection_string;

--- a/migrations/2024-11-24-191420_add_indexer_custom_connection_string/up.sql
+++ b/migrations/2024-11-24-191420_add_indexer_custom_connection_string/up.sql
@@ -1,0 +1,4 @@
+-- Your SQL goes here
+-- Add custom connection string column
+ALTER TABLE indexers
+ADD COLUMN custom_connection_string VARCHAR;

--- a/src/domain/models/indexer.rs
+++ b/src/domain/models/indexer.rs
@@ -41,6 +41,7 @@ pub struct IndexerModel {
     pub target_url: Option<String>,
     pub table_name: Option<String>,
     pub status_server_port: Option<i32>,
+    pub custom_connection_string: Option<String>,
 }
 
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]

--- a/src/handlers/indexers/indexer_types/mod.rs
+++ b/src/handlers/indexers/indexer_types/mod.rs
@@ -212,6 +212,7 @@ mod tests {
             target_url: Some("https://example.com".to_string()),
             table_name: None,
             status_server_port: Some(1234),
+            custom_connection_string: None,
         };
 
         // clear the sqs queue

--- a/src/handlers/indexers/indexer_types/postgres.rs
+++ b/src/handlers/indexers/indexer_types/postgres.rs
@@ -10,7 +10,10 @@ pub struct PostgresIndexer;
 impl Indexer for PostgresIndexer {
     async fn start(&self, indexer: &IndexerModel, attempt: u32) -> Result<u32, IndexerError> {
         let binary_file = format!("{}/{}", get_environment_variable("BINARY_BASE_PATH"), "sink-postgres");
-        let postgres_connection_string = get_environment_variable("APIBARA_POSTGRES_CONNECTION_STRING");
+        let postgres_connection_string = indexer
+            .custom_connection_string
+            .clone()
+            .unwrap_or_else(|| get_environment_variable("APIBARA_POSTGRES_CONNECTION_STRING"));
         let table_name = indexer.table_name.as_ref().expect("`table_name` not set for postgres indexer");
         let id = self.start_common(
             binary_file,

--- a/src/infra/db/schema.rs
+++ b/src/infra/db/schema.rs
@@ -10,6 +10,7 @@ diesel::table! {
         target_url -> Nullable<Varchar>,
         table_name -> Nullable<Varchar>,
         status_server_port -> Nullable<Int4>,
+        custom_connection_string -> Nullable<Varchar>,
     }
 }
 

--- a/src/infra/repositories/indexer_repository.rs
+++ b/src/infra/repositories/indexer_repository.rs
@@ -23,6 +23,7 @@ pub struct IndexerDb {
     pub target_url: Option<String>,
     pub table_name: Option<String>,
     pub status_server_port: Option<i32>,
+    pub custom_connection_string: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -39,6 +40,7 @@ pub struct NewIndexerDb {
     pub target_url: Option<String>,
     pub table_name: Option<String>,
     pub status_server_port: Option<i32>,
+    pub custom_connection_string: Option<String>,
 }
 
 #[derive(Deserialize, Insertable)]
@@ -220,6 +222,7 @@ impl TryFrom<NewIndexerDb> for IndexerModel {
             process_id: None,
             table_name: value.table_name,
             status_server_port: value.status_server_port,
+            custom_connection_string: value.custom_connection_string,
         }
         .try_into()?;
         Ok(model)
@@ -237,6 +240,7 @@ impl TryFrom<IndexerDb> for IndexerModel {
             target_url: value.target_url,
             table_name: value.table_name,
             status_server_port: value.status_server_port,
+            custom_connection_string: value.custom_connection_string,
         };
         Ok(model)
     }
@@ -273,6 +277,7 @@ mod tests {
             target_url: Some(target_url.to_string()),
             table_name: Some(table_name.into()),
             status_server_port: Some(1234),
+            custom_connection_string: None,
         };
 
         let indexer_model: Result<IndexerModel, ParseError> = indexer_db.try_into();
@@ -313,6 +318,7 @@ mod tests {
             target_url: Some(target_url.to_string()),
             table_name: Some(table_name.into()),
             status_server_port: Some(1234),
+            custom_connection_string: None,
         };
 
         let indexer_model: Result<IndexerModel, ParseError> = indexer_db.try_into();

--- a/src/tests/common/mod.rs
+++ b/src/tests/common/mod.rs
@@ -30,6 +30,7 @@ impl MockRepository {
                     target_url: Some("https://example.com".to_string()),
                     table_name: None,
                     status_server_port: None,
+                    custom_connection_string: None,
                 },
                 IndexerModel {
                     id: uuid::Uuid::new_v4(),
@@ -39,6 +40,7 @@ impl MockRepository {
                     target_url: Some("https://example.com".to_string()),
                     table_name: None,
                     status_server_port: None,
+                    custom_connection_string: None,
                 },
                 IndexerModel {
                     id: uuid::Uuid::new_v4(),
@@ -48,6 +50,7 @@ impl MockRepository {
                     target_url: Some("https://example.com".to_string()),
                     table_name: None,
                     status_server_port: None,
+                    custom_connection_string: None,
                 },
                 IndexerModel {
                     id: uuid::Uuid::new_v4(),
@@ -57,6 +60,7 @@ impl MockRepository {
                     target_url: Some("https://example.com".to_string()),
                     table_name: None,
                     status_server_port: None,
+                    custom_connection_string: None,
                 },
                 IndexerModel {
                     id: uuid::Uuid::new_v4(),
@@ -66,6 +70,7 @@ impl MockRepository {
                     target_url: Some("https://example.com".to_string()),
                     table_name: None,
                     status_server_port: None,
+                    custom_connection_string: None,
                 },
             ],
         }

--- a/src/tests/repository.rs
+++ b/src/tests/repository.rs
@@ -23,6 +23,7 @@ async fn test_get_indexer() {
             target_url: Some("https://example.com".to_string()), // TODO: Mock webhook and test its behavior
             table_name: None,
             status_server_port: None,
+            custom_connection_string: None,
         })
         .await
         .unwrap();
@@ -54,6 +55,7 @@ async fn test_insert_indexer() {
             target_url: Some("https://example.com".to_string()),
             table_name: None,
             status_server_port: None,
+            custom_connection_string: None,
         })
         .await
         .unwrap();
@@ -82,6 +84,7 @@ async fn test_update_status() {
             target_url: Some("https://example.com".to_string()),
             table_name: None,
             status_server_port: None,
+            custom_connection_string: None,
         })
         .await
         .unwrap();
@@ -109,6 +112,7 @@ async fn test_update_status_and_process_id() {
             target_url: Some("https://example.com".to_string()),
             table_name: None,
             status_server_port: None,
+            custom_connection_string: None,
         })
         .await
         .unwrap();
@@ -144,6 +148,7 @@ async fn test_get_all_indexers() {
                 target_url: Some("https://example.com".to_string()),
                 table_name: None,
                 status_server_port: None,
+                custom_connection_string: None,
             })
             .await
             .unwrap();
@@ -158,6 +163,7 @@ async fn test_get_all_indexers() {
             target_url: Some("https://example.com".to_string()),
             table_name: None,
             status_server_port: None,
+            custom_connection_string: None,
         })
         .await
         .unwrap();


### PR DESCRIPTION
## Changes
- Adds support for a new `connection_string` param when creating an indexer
if note specified it will use the env var, this is to avoid breaking changes